### PR TITLE
Fix equil scenario and test

### DIFF
--- a/assets/equil/equil-config.yml
+++ b/assets/equil/equil-config.yml
@@ -22,3 +22,4 @@ modules:
     end_time: 86400
     sample_size: 1.0
     stuck_threshold: 1000
+    main_modes: ["car"]

--- a/tests/resources/equil/equil-config.yml
+++ b/tests/resources/equil/equil-config.yml
@@ -1,0 +1,19 @@
+modules:
+  protofiles:
+    type: ProtoFiles
+    network: ./test_output/simulation/equil/equil-network.binpb
+    population: ./test_output/simulation/equil/equil-1-plan.binpb
+    vehicles: ./test_output/simulation/equil/equil-vehicles.binpb
+    ids: ./test_output/simulation/equil/ids.binpb
+  partitioning:
+    type: Partitioning
+    num_parts: 1
+    method: !Metis
+      vertex_weight:
+        - Constant
+  output:
+    type: Output
+    output_dir: ./test_output/simulation/equil
+  routing:
+    type: Routing
+    mode: UsePlans

--- a/tests/test_equil.rs
+++ b/tests/test_equil.rs
@@ -1,12 +1,33 @@
+use std::path::PathBuf;
+
 mod test_simulation;
 use test_simulation::execute_sim_with_channels;
 use rust_q_sim::simulation::config::CommandLineArgs;
+use rust_q_sim::simulation::id::store_to_file;
+use rust_q_sim::simulation::network::global_network::Network;
+use rust_q_sim::simulation::population::population_data::Population;
+use rust_q_sim::simulation::vehicles::garage::Garage;
+
+fn create_resources(out_dir: &PathBuf) {
+    let input_dir = PathBuf::from("./assets/equil/");
+    let net = Network::from_file_as_is(&input_dir.join("equil-network.xml"));
+    let mut garage = Garage::from_file(&input_dir.join("equil-vehicles.xml"));
+    let pop = Population::from_file(&input_dir.join("equil-1-plan.xml"), &mut garage);
+
+    store_to_file(&out_dir.join("ids.binpb"));
+    net.to_file(&out_dir.join("equil-network.binpb"));
+    pop.to_file(&out_dir.join("equil-1-plan.binpb"));
+    garage.to_file(&out_dir.join("equil-vehicles.binpb"));
+}
 
 #[test]
 fn test_equil_scenario() {
+    let test_dir = PathBuf::from("./test_output/simulation/equil/");
+    create_resources(&test_dir);
+
     let args = CommandLineArgs {
-        config_path: "assets/equil/equil-config.yml".to_string(),
-        num_parts:   Some(1),
+        config_path: "./tests/resources/equil/equil-config.yml".to_string(),
+        num_parts: None,
     };
-    execute_sim_with_channels(args, "tests/resources/equil/expected_events.xml");
+    execute_sim_with_channels(args, "./tests/resources/equil/expected_events.xml");
 }


### PR DESCRIPTION
## Summary
- generate equil scenario test resources like in 3-links
- update equil test to create binary resources before running
- fix original equil config by adding missing `main_modes`

## Testing
- `cargo test --test test_equil --release` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685127755b908320af3fdd791ee8b61c