### PR TITLE
Add teleportation tests for equil scenario

### DIFF
--- a/assets/equil/equil-generic-one-leg.xml
+++ b/assets/equil/equil-generic-one-leg.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE population SYSTEM "http://www.matsim.org/files/dtd/population_v6.dtd">
+<population>
+    <person id="1">
+        <attributes>
+            <attribute name="vehicles" class="org.matsim.vehicles.PersonVehicles">{"car":"1"}</attribute>
+        </attributes>
+        <plan score="0" selected="yes">
+            <activity type="h" link="1" x="-25000.0" y="0.0" end_time="06:00:00" />
+            <leg mode="car" dep_time="06:00:00" trav_time="00:01:00">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">car</attribute>
+                </attributes>
+                <route type="generic" start_link="1" end_link="20" trav_time="00:01:00" distance="25000.0" />
+            </leg>
+            <activity type="w" link="20" x="3456.0" y="4242.0" />
+        </plan>
+    </person>
+</population>

--- a/assets/equil/equil-network-one-leg.xml
+++ b/assets/equil/equil-network-one-leg.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE population SYSTEM "http://www.matsim.org/files/dtd/population_v6.dtd">
+<population>
+    <person id="1">
+        <attributes>
+            <attribute name="vehicles" class="org.matsim.vehicles.PersonVehicles">{"car":"1"}</attribute>
+        </attributes>
+        <plan score="0" selected="yes">
+            <activity type="h" link="1" x="-25000.0" y="0.0" end_time="06:00:00" />
+            <leg mode="car" dep_time="06:00:00" trav_time="00:01:00">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">car</attribute>
+                </attributes>
+                <route type="links" start_link="1" end_link="20" trav_time="00:01:00" distance="25000.0" vehicleRefId="1_car">1 6 15 20</route>
+            </leg>
+            <activity type="w" link="20" x="3456.0" y="4242.0" />
+        </plan>
+    </person>
+</population>

--- a/tests/resources/equil/equil-config-gen-main.yml
+++ b/tests/resources/equil/equil-config-gen-main.yml
@@ -1,0 +1,26 @@
+modules:
+  protofiles:
+    type: ProtoFiles
+    network: ./test_output/simulation/equil_gen_main/equil-network.binpb
+    population: ./test_output/simulation/equil_gen_main/equil-plan.binpb
+    vehicles: ./test_output/simulation/equil_gen_main/equil-vehicles.binpb
+    ids: ./test_output/simulation/equil_gen_main/ids.binpb
+  partitioning:
+    type: Partitioning
+    num_parts: 1
+    method: !Metis
+      vertex_weight:
+        - Constant
+  output:
+    type: Output
+    output_dir: ./test_output/simulation/equil_gen_main
+  routing:
+    type: Routing
+    mode: UsePlans
+  simulation:
+    type: Simulation
+    start_time: 0
+    end_time: 86400
+    sample_size: 1.0
+    stuck_threshold: 1000
+    main_modes: ["car"]

--- a/tests/resources/equil/equil-config-gen-no-main.yml
+++ b/tests/resources/equil/equil-config-gen-no-main.yml
@@ -1,0 +1,26 @@
+modules:
+  protofiles:
+    type: ProtoFiles
+    network: ./test_output/simulation/equil_gen_no_main/equil-network.binpb
+    population: ./test_output/simulation/equil_gen_no_main/equil-plan.binpb
+    vehicles: ./test_output/simulation/equil_gen_no_main/equil-vehicles.binpb
+    ids: ./test_output/simulation/equil_gen_no_main/ids.binpb
+  partitioning:
+    type: Partitioning
+    num_parts: 1
+    method: !Metis
+      vertex_weight:
+        - Constant
+  output:
+    type: Output
+    output_dir: ./test_output/simulation/equil_gen_no_main
+  routing:
+    type: Routing
+    mode: UsePlans
+  simulation:
+    type: Simulation
+    start_time: 0
+    end_time: 86400
+    sample_size: 1.0
+    stuck_threshold: 1000
+    main_modes: []

--- a/tests/resources/equil/equil-config-net-no-main.yml
+++ b/tests/resources/equil/equil-config-net-no-main.yml
@@ -1,0 +1,26 @@
+modules:
+  protofiles:
+    type: ProtoFiles
+    network: ./test_output/simulation/equil_net_no_main/equil-network.binpb
+    population: ./test_output/simulation/equil_net_no_main/equil-plan.binpb
+    vehicles: ./test_output/simulation/equil_net_no_main/equil-vehicles.binpb
+    ids: ./test_output/simulation/equil_net_no_main/ids.binpb
+  partitioning:
+    type: Partitioning
+    num_parts: 1
+    method: !Metis
+      vertex_weight:
+        - Constant
+  output:
+    type: Output
+    output_dir: ./test_output/simulation/equil_net_no_main
+  routing:
+    type: Routing
+    mode: UsePlans
+  simulation:
+    type: Simulation
+    start_time: 0
+    end_time: 86400
+    sample_size: 1.0
+    stuck_threshold: 1000
+    main_modes: []

--- a/tests/resources/equil/expected_events_teleport.xml
+++ b/tests/resources/equil/expected_events_teleport.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<events version="1.0">
+    <event time="21600" type="actend" person="1" link="1" actType="h"/>
+    <event time="21600" type="departure" person="1" link="1" legMode="car"/>
+    <event time="21660" type="travelled" person="1" distance="25000" mode="car"/>
+    <event time="21660" type="arrival" person="1" link="20" legMode="car"/>
+    <event time="21661" type="actstart" person="1" link="20" actType="w"/>
+</events>

--- a/tests/test_equil.rs
+++ b/tests/test_equil.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 mod test_simulation;
-use test_simulation::{execute_sim, execute_sim_with_channels, TestSubscriber};
+use test_simulation::{execute_sim, execute_sim_with_channels, TestSubscriber, DummySubscriber};
 use rust_q_sim::simulation::config::CommandLineArgs;
 use rust_q_sim::simulation::id::store_to_file;
 use rust_q_sim::simulation::messaging::communication::local_communicator::DummySimCommunicator;
@@ -9,22 +9,22 @@ use rust_q_sim::simulation::network::global_network::Network;
 use rust_q_sim::simulation::population::population_data::Population;
 use rust_q_sim::simulation::vehicles::garage::Garage;
 
-fn create_resources(out_dir: &PathBuf) {
+fn create_resources(plan_file: &str, out_dir: &PathBuf) {
     let input_dir = PathBuf::from("./assets/equil/");
     let net = Network::from_file_as_is(&input_dir.join("equil-network.xml"));
     let mut garage = Garage::from_file(&input_dir.join("equil-vehicles.xml"));
-    let pop = Population::from_file(&input_dir.join("equil-1-plan.xml"), &mut garage);
+    let pop = Population::from_file(&PathBuf::from(plan_file), &mut garage);
 
     store_to_file(&out_dir.join("ids.binpb"));
     net.to_file(&out_dir.join("equil-network.binpb"));
-    pop.to_file(&out_dir.join("equil-1-plan.binpb"));
+    pop.to_file(&out_dir.join("equil-plan.binpb"));
     garage.to_file(&out_dir.join("equil-vehicles.binpb"));
 }
 
 #[test]
 fn execute_equil_single_part() {
     let test_dir = PathBuf::from("./test_output/simulation/equil_single_part/");
-    create_resources(&test_dir);
+    create_resources("./assets/equil/equil-1-plan.xml", &test_dir);
 
     let config_args = CommandLineArgs {
         config_path: "./tests/resources/equil/equil-config-1.yml".to_string(),
@@ -43,7 +43,7 @@ fn execute_equil_single_part() {
 #[test]
 fn execute_equil_2_parts() {
     let test_dir = PathBuf::from("./test_output/simulation/equil_with_channels/");
-    create_resources(&test_dir);
+    create_resources("./assets/equil/equil-1-plan.xml", &test_dir);
 
     let config_args = CommandLineArgs {
         config_path: "./tests/resources/equil/equil-config-2.yml".to_string(),
@@ -53,5 +53,61 @@ fn execute_equil_2_parts() {
     execute_sim_with_channels(
         config_args,
         "./tests/resources/equil/expected_events.xml",
+    );
+}
+
+#[test]
+fn network_route_car_not_main_mode() {
+    let test_dir = PathBuf::from("./test_output/simulation/equil_net_no_main/");
+    create_resources("./assets/equil/equil-network-one-leg.xml", &test_dir);
+
+    let config_args = CommandLineArgs {
+        config_path: "./tests/resources/equil/equil-config-net-no-main.yml".to_string(),
+        num_parts: None,
+    };
+
+    execute_sim(
+        DummySimCommunicator(),
+        Box::new(TestSubscriber::new_with_events_from_file(
+            "./tests/resources/equil/expected_events_teleport.xml",
+        )),
+        config_args,
+    );
+}
+
+#[test]
+fn generic_route_car_not_main_mode() {
+    let test_dir = PathBuf::from("./test_output/simulation/equil_gen_no_main/");
+    create_resources("./assets/equil/equil-generic-one-leg.xml", &test_dir);
+
+    let config_args = CommandLineArgs {
+        config_path: "./tests/resources/equil/equil-config-gen-no-main.yml".to_string(),
+        num_parts: None,
+    };
+
+    execute_sim(
+        DummySimCommunicator(),
+        Box::new(TestSubscriber::new_with_events_from_file(
+            "./tests/resources/equil/expected_events_teleport.xml",
+        )),
+        config_args,
+    );
+}
+
+#[test]
+#[should_panic]
+fn generic_route_car_main_mode_should_crash() {
+    let test_dir = PathBuf::from("./test_output/simulation/equil_gen_main/");
+    create_resources("./assets/equil/equil-generic-one-leg.xml", &test_dir);
+
+    let config_args = CommandLineArgs {
+        config_path: "./tests/resources/equil/equil-config-gen-main.yml".to_string(),
+        num_parts: None,
+    };
+
+    execute_sim(
+        DummySimCommunicator(),
+        Box::new(DummySubscriber {}),
+        config_args,
     );
 }


### PR DESCRIPTION
## Summary
- create single-leg plans for network and generic routes
- add configs for car main mode and no main mode
- add expected events for teleported car
- cover teleportation cases in `test_equil`

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo test --quiet` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ec934ef748320934fc53b98422c31