### PR TITLE
Add teleportation tests for equil scenario

### DIFF
--- a/assets/equil/equil-1-plan-generic.xml
+++ b/assets/equil/equil-1-plan-generic.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE population SYSTEM "http://www.matsim.org/files/dtd/population_v6.dtd">
+
+<population>
+
+    <attributes>
+        <attribute name="coordinateReferenceSystem" class="java.lang.String">Atlantis</attribute>
+    </attributes>
+
+
+    <!-- ====================================================================== -->
+
+    <person id="1">
+        <attributes>
+            <attribute name="vehicles" class="org.matsim.vehicles.PersonVehicles">{"car":"1"}</attribute>
+        </attributes>
+        <plan score="53.10347962692449" selected="yes">
+            <activity type="h" link="1" x="-25000.0" y="0.0" end_time="06:00:00">
+            </activity>
+            <leg mode="car">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">car</attribute>
+                </attributes>
+                <route type="generic" start_link="1" end_link="20" trav_time="undefined" distance="25000.0"
+/>
+            </leg>
+            <activity type="w" link="20" x="3456.0" y="4242.0" max_dur="00:10:00">
+            </activity>
+            <leg mode="car">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">car</attribute>
+                </attributes>
+                <route type="generic" start_link="20" end_link="20" trav_time="undefined" distance="0.0"
+/>
+            </leg>
+            <activity type="w" link="20" x="10000.0" y="0.0" max_dur="03:30:00">
+            </activity>
+            <leg mode="car">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">car</attribute>
+                </attributes>
+                <route type="generic" start_link="20" end_link="1" trav_time="undefined" distance="65000.0"
+/>
+            </leg>
+            <activity type="h" link="1" x="-25000.0" y="0.0">
+            </activity>
+        </plan>
+
+        <plan score="52.9312834015057" selected="no">
+            <activity type="h" link="1" x="-25000.0" y="0.0" end_time="06:00:00">
+            </activity>
+            <leg mode="car" dep_time="06:00:00" trav_time="00:08:59">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">car</attribute>
+                </attributes>
+                <route type="generic" start_link="1" end_link="20" trav_time="00:08:59" distance="25000.0"
+/>
+            </leg>
+            <activity type="w" link="20" x="10000.0" y="0.0" max_dur="00:10:00">
+            </activity>
+            <leg mode="car" dep_time="06:18:59" trav_time="00:00:00">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">car</attribute>
+                </attributes>
+                <route type="generic" start_link="20" end_link="20" trav_time="00:00:00" distance="0.0"
+/>
+            </leg>
+            <activity type="w" link="20" x="10000.0" y="0.0" max_dur="03:30:00">
+            </activity>
+            <leg mode="car" dep_time="09:48:59" trav_time="00:32:59">
+                <attributes>
+                    <attribute name="routingMode" class="java.lang.String">car</attribute>
+                </attributes>
+                <route type="generic" start_link="20" end_link="1" trav_time="00:32:59" distance="65000.0"
+/>
+            </leg>
+            <activity type="h" link="1" x="-25000.0" y="0.0">
+            </activity>
+        </plan>
+
+    </person>
+
+</population>

--- a/tests/resources/equil/equil-config-generic-main.yml
+++ b/tests/resources/equil/equil-config-generic-main.yml
@@ -1,0 +1,23 @@
+modules:
+  protofiles:
+    type: ProtoFiles
+    network: ./test_output/simulation/equil_generic_main/equil-network.binpb
+    population: ./test_output/simulation/equil_generic_main/equil-1-plan-generic.binpb
+    vehicles: ./test_output/simulation/equil_generic_main/equil-vehicles.binpb
+    ids: ./test_output/simulation/equil_generic_main/ids.binpb
+  partitioning:
+    type: Partitioning
+    num_parts: 1
+    method: !Metis
+      vertex_weight:
+        - Constant
+  output:
+    type: Output
+    output_dir: ./test_output/simulation/equil_generic_main
+  routing:
+    type: Routing
+    mode: UsePlans
+  simulation:
+    type: Simulation
+    main_modes:
+      - car

--- a/tests/resources/equil/equil-config-generic-no-main.yml
+++ b/tests/resources/equil/equil-config-generic-no-main.yml
@@ -1,0 +1,22 @@
+modules:
+  protofiles:
+    type: ProtoFiles
+    network: ./test_output/simulation/equil_generic_no_main/equil-network.binpb
+    population: ./test_output/simulation/equil_generic_no_main/equil-1-plan-generic.binpb
+    vehicles: ./test_output/simulation/equil_generic_no_main/equil-vehicles.binpb
+    ids: ./test_output/simulation/equil_generic_no_main/ids.binpb
+  partitioning:
+    type: Partitioning
+    num_parts: 1
+    method: !Metis
+      vertex_weight:
+        - Constant
+  output:
+    type: Output
+    output_dir: ./test_output/simulation/equil_generic_no_main
+  routing:
+    type: Routing
+    mode: UsePlans
+  simulation:
+    type: Simulation
+    main_modes: []

--- a/tests/resources/equil/equil-config-network-no-main.yml
+++ b/tests/resources/equil/equil-config-network-no-main.yml
@@ -1,0 +1,22 @@
+modules:
+  protofiles:
+    type: ProtoFiles
+    network: ./test_output/simulation/equil_network_no_main/equil-network.binpb
+    population: ./test_output/simulation/equil_network_no_main/equil-1-plan.binpb
+    vehicles: ./test_output/simulation/equil_network_no_main/equil-vehicles.binpb
+    ids: ./test_output/simulation/equil_network_no_main/ids.binpb
+  partitioning:
+    type: Partitioning
+    num_parts: 1
+    method: !Metis
+      vertex_weight:
+        - Constant
+  output:
+    type: Output
+    output_dir: ./test_output/simulation/equil_network_no_main
+  routing:
+    type: Routing
+    mode: UsePlans
+  simulation:
+    type: Simulation
+    main_modes: []

--- a/tests/resources/equil/expected_events_teleport.xml
+++ b/tests/resources/equil/expected_events_teleport.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<events version="1.0">
+    <event time="21600" type="actend" person="1" link="1" actType="h"/>
+    <event time="21600" type="departure" person="1" link="1" legMode="car"/>
+    <event time="21600" type="travelled" person="1" distance="25000" mode="car"/>
+    <event time="21600" type="arrival" person="1" link="20" legMode="car"/>
+    <event time="21601" type="actstart" person="1" link="20" actType="w"/>
+    <event time="22201" type="actend" person="1" link="20" actType="w"/>
+    <event time="22201" type="departure" person="1" link="20" legMode="car"/>
+    <event time="22201" type="travelled" person="1" distance="0" mode="car"/>
+    <event time="22201" type="arrival" person="1" link="20" legMode="car"/>
+    <event time="22202" type="actstart" person="1" link="20" actType="w"/>
+    <event time="34802" type="actend" person="1" link="20" actType="w"/>
+    <event time="34802" type="departure" person="1" link="20" legMode="car"/>
+    <event time="34802" type="travelled" person="1" distance="65000" mode="car"/>
+    <event time="34802" type="arrival" person="1" link="1" legMode="car"/>
+    <event time="34803" type="actstart" person="1" link="1" actType="h"/>
+</events>

--- a/tests/test_equil.rs
+++ b/tests/test_equil.rs
@@ -10,14 +10,19 @@ use rust_q_sim::simulation::population::population_data::Population;
 use rust_q_sim::simulation::vehicles::garage::Garage;
 
 fn create_resources(out_dir: &PathBuf) {
+    create_resources_with_plan(out_dir, "equil-1-plan.xml");
+}
+
+fn create_resources_with_plan(out_dir: &PathBuf, plan_file: &str) {
     let input_dir = PathBuf::from("./assets/equil/");
     let net = Network::from_file_as_is(&input_dir.join("equil-network.xml"));
     let mut garage = Garage::from_file(&input_dir.join("equil-vehicles.xml"));
-    let pop = Population::from_file(&input_dir.join("equil-1-plan.xml"), &mut garage);
+    let pop = Population::from_file(&input_dir.join(plan_file), &mut garage);
 
     store_to_file(&out_dir.join("ids.binpb"));
     net.to_file(&out_dir.join("equil-network.binpb"));
-    pop.to_file(&out_dir.join("equil-1-plan.binpb"));
+    let plan_bin = plan_file.replace(".xml", ".binpb");
+    pop.to_file(&out_dir.join(plan_bin));
     garage.to_file(&out_dir.join("equil-vehicles.binpb"));
 }
 
@@ -53,5 +58,63 @@ fn execute_equil_2_parts() {
     execute_sim_with_channels(
         config_args,
         "./tests/resources/equil/expected_events.xml",
+    );
+}
+
+#[test]
+fn network_route_no_main_mode() {
+    let test_dir = PathBuf::from("./test_output/simulation/equil_network_no_main/");
+    create_resources_with_plan(&test_dir, "equil-1-plan.xml");
+
+    let config_args = CommandLineArgs {
+        config_path: "./tests/resources/equil/equil-config-network-no-main.yml".to_string(),
+        num_parts: None,
+    };
+
+    execute_sim(
+        DummySimCommunicator(),
+        Box::new(TestSubscriber::new_with_events_from_file(
+            "./tests/resources/equil/expected_events_teleport.xml",
+        )),
+        config_args,
+    );
+}
+
+#[test]
+fn generic_route_no_main_mode() {
+    let test_dir = PathBuf::from("./test_output/simulation/equil_generic_no_main/");
+    create_resources_with_plan(&test_dir, "equil-1-plan-generic.xml");
+
+    let config_args = CommandLineArgs {
+        config_path: "./tests/resources/equil/equil-config-generic-no-main.yml".to_string(),
+        num_parts: None,
+    };
+
+    execute_sim(
+        DummySimCommunicator(),
+        Box::new(TestSubscriber::new_with_events_from_file(
+            "./tests/resources/equil/expected_events_teleport.xml",
+        )),
+        config_args,
+    );
+}
+
+#[test]
+#[should_panic]
+fn generic_route_main_mode() {
+    let test_dir = PathBuf::from("./test_output/simulation/equil_generic_main/");
+    create_resources_with_plan(&test_dir, "equil-1-plan-generic.xml");
+
+    let config_args = CommandLineArgs {
+        config_path: "./tests/resources/equil/equil-config-generic-main.yml".to_string(),
+        num_parts: None,
+    };
+
+    execute_sim(
+        DummySimCommunicator(),
+        Box::new(TestSubscriber::new_with_events_from_file(
+            "./tests/resources/equil/expected_events_teleport.xml",
+        )),
+        config_args,
     );
 }


### PR DESCRIPTION
## Summary
- add a generic plan for the equil scenario
- add config files for generic and network teleportation cases
- define expected events when agents are teleported
- extend `create_resources` to allow choosing the plan
- implement three new tests covering teleportation behaviour and the crash case

## Testing
- `cargo test --offline -- --nocapture` *(fails: no matching package named `assert_approx_eq` found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec934ef748320934fc53b98422c31